### PR TITLE
fix: remove unused field in CREATE_CV mutation

### DIFF
--- a/src/graphql/mutations/cv.ts
+++ b/src/graphql/mutations/cv.ts
@@ -7,7 +7,6 @@ export const CREATE_CV = gql`
       created_at
       name
       description
-      user
       skills {
         skill_name
         mastery


### PR DESCRIPTION
1. Удалил ненужное возвращаемое поле (Из-за которого была ошибка)
close #109 